### PR TITLE
Fix capitalization of HTML entities

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -126,7 +126,7 @@ export default function PrivacyPolicy() {
                           </li>
                           <li>
                             <strong>Favorite Repositories:</strong> If you use
-                            the &QUOT;favorite&QUOT; feature, we store the
+                            the &quot;favorite&quot; feature, we store the
                             GitHub repository URL, owner, and name associated
                             with your user ID.
                           </li>
@@ -275,7 +275,7 @@ export default function PrivacyPolicy() {
                             <li>
                               <strong>Google AI (Gemini):</strong> Your chat
                               messages (excluding your personal identity) are
-                              sent to Google&QUOT;s AI models to generate
+                              sent to Google&quot;s AI models to generate
                               responses.
                             </li>
                             <li>
@@ -375,7 +375,7 @@ export default function PrivacyPolicy() {
 
                 <Section
                   number="8"
-                  title="Children&QUOT;s Privacy"
+                  title="Children&quot;s Privacy"
                   icon={<Users className="h-5 w-5" />}
                   content="Our Service is not intended for use by individuals under the age of 13. We do not knowingly collect personally identifiable information from children under 13. If you are a parent or guardian and you are aware that your child has provided us with personal data, please contact us. If we become aware that we have collected personal data from a child under 13 without verification of parental consent, we take steps to remove that information from our servers."
                 />
@@ -384,7 +384,7 @@ export default function PrivacyPolicy() {
                   number="9"
                   title="Changes to This Privacy Policy"
                   icon={<Calendar className="h-5 w-5" />}
-                  content="We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the &QUOT;Last Updated&QUOT; date. You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page."
+                  content="We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the &quot;Last Updated&quot; date. You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page."
                 />
 
                 <Section

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -117,8 +117,8 @@ export default function TermsOfService() {
                           or any activities conducted on the Service.
                         </li>
                         <li>
-                          Misusing GitHub&APOS;s API or data accessed through
-                          the Service in a manner that violates GitHub&APOS;s
+                          Misusing GitHub&apos;s API or data accessed through
+                          the Service in a manner that violates GitHub&apos;s
                           terms of service.
                         </li>
                       </ul>
@@ -166,7 +166,7 @@ export default function TermsOfService() {
                       <li>
                         Access to additional messages and features may require a
                         paid subscription, processed via Stripe. All
-                        subscription payments are subject to Stripe&APOS;s terms
+                          subscription payments are subject to Stripe&apos;s terms
                         and conditions.
                       </li>
                       <li>Subscription fees are generally non-refundable.</li>
@@ -189,7 +189,7 @@ export default function TermsOfService() {
                         </li>
                         <li>
                           <strong>Google AI:</strong> For powering the AI
-                          assistant&APOS;s responses.
+                          assistant&apos;s responses.
                         </li>
                         <li>
                           <strong>Stripe:</strong> For payment processing and
@@ -209,7 +209,7 @@ export default function TermsOfService() {
                 <Section
                   number="9"
                   title="Disclaimer of Warranties"
-                  content="The Service is provided on an &APOS;as is&APOS; and &APOS;as available&APOS; basis, without any warranties of any kind, either express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement, or course of performance. Makkara Chat does not warrant that the Service will be uninterrupted, secure, or error-free."
+                  content="The Service is provided on an &apos;as is&apos; and &apos;as available&apos; basis, without any warranties of any kind, either express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement, or course of performance. Makkara Chat does not warrant that the Service will be uninterrupted, secure, or error-free."
                 />
 
                 <Section
@@ -227,7 +227,7 @@ export default function TermsOfService() {
                 <Section
                   number="12"
                   title="Changes to Terms"
-                  content="We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will try to provide at least 30 days&APOS; notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion. By continuing to access or use our Service after those revisions become effective, you agree to be bound by the revised terms."
+                  content="We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will try to provide at least 30 days&apos; notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion. By continuing to access or use our Service after those revisions become effective, you agree to be bound by the revised terms."
                 />
 
                 <Section
@@ -253,7 +253,7 @@ export default function TermsOfService() {
                 Questions about these terms?
               </h3>
               <p className="text-muted-foreground mb-4">
-                We&APOS;re here to help. Contact us if you need clarification on
+                We&apos;re here to help. Contact us if you need clarification on
                 any of these terms.
               </p>
               <Button asChild>


### PR DESCRIPTION
## Summary
- replace uppercase HTML entities in terms and privacy pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c8c402a4832f875311270506e75f