### PR TITLE
Add harshness slider to chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -108,7 +108,9 @@ export async function POST(req: Request) {
       );
     }
 
-    const { messages, repository } = await req.json();
+    const { messages, repository, harshness } = await req.json();
+
+    const toneLevel = typeof harshness === "number" ? harshness : parseInt(harshness ?? "5", 10);
 
     if (!repository) {
       return new Response("Repository information is required", {
@@ -119,7 +121,8 @@ export async function POST(req: Request) {
     const [owner, repo] = repository.split("/");
     const repoContent = await getRepositoryContent(owner, repo);
 
-    const systemPrompt = `You are an AI assistant for Makkara Chat, that helps users understand and work with GitHub repositories. 
+    const systemPrompt = `You are an AI assistant for Makkara Chat, that helps users understand and work with GitHub repositories.
+Your responses should match a harshness level of ${toneLevel}/10, where 0 is a caring mom and 10 is Linus Torvalds levels of directness. Keep it helpful and fun.
 
 - Answer user's question about the repository. Be concise but informative.
 - If user asks about who are you, you should introduce yourself as MakkaraPoika69, a AI assistant for Makkara Chat.

--- a/app/chat/[repository]/ChatComponent.tsx
+++ b/app/chat/[repository]/ChatComponent.tsx
@@ -102,6 +102,7 @@ export default function ChatComponent() {
   const [rateLimitError, setRateLimitError] = useState<string | null>(null);
   const [repoError, setRepoError] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(true);
+  const [harshness, setHarshness] = useState(5);
   const router = useRouter();
 
   const scrollToBottom = () => {
@@ -153,7 +154,7 @@ export default function ChatComponent() {
     setInput,
   } = useChat({
     api: "/api/chat",
-    body: { repository },
+    body: { repository, harshness },
     onError: (error) => {
       try {
         const errorData = JSON.parse(error.message);
@@ -488,6 +489,19 @@ export default function ChatComponent() {
               </Alert>
             </div>
           )}
+
+          <div className="max-w-4xl mx-auto mb-4 flex items-center gap-3">
+            <span className="text-xs">Mom</span>
+            <input
+              type="range"
+              min={0}
+              max={10}
+              value={harshness}
+              onChange={(e) => setHarshness(Number(e.target.value))}
+              className="flex-1"
+            />
+            <span className="text-xs">Linus Torvalds</span>
+          </div>
 
           <form onSubmit={handleSubmit} className="max-w-4xl mx-auto">
             <div className="flex gap-3 p-2 bg-background rounded-xl border border-border/50 shadow-sm focus-within:border-primary/50 focus-within:shadow-md transition-all duration-200">


### PR DESCRIPTION
## Summary
- add a harshness slider to ChatComponent
- send the selected harshness level to the chat API
- adjust API system prompt based on the harshness level

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb0c75f4832fabc730760863e0cb