### PR TITLE
Add header for logged in users

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SessionProvider } from "next-auth/react";
+import { auth } from "@/auth";
+import SignedInHeader from "@/components/SignedInHeader";
 import { Analytics } from "@vercel/analytics/next"
 import CookieConsent from "@/components/CookieConsent";
 
@@ -22,14 +24,16 @@ export const metadata: Metadata = {
   description: "Understand any codebase through natural conversation with AI",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await auth();
+
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
-      <SessionProvider>
+      <SessionProvider session={session}>
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background`}
         >
@@ -43,6 +47,7 @@ export default function RootLayout({
           >
             <Analytics />
             <CookieConsent />
+            {session?.user && <SignedInHeader user={session.user} />}
             <Toaster />
             {children}
           </ThemeProvider>

--- a/components/SignedInHeader.tsx
+++ b/components/SignedInHeader.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { signOut } from "next-auth/react";
+import Link from "next/link";
+
+interface SignedInHeaderProps {
+  user: {
+    name?: string | null;
+    image?: string | null;
+  };
+}
+
+export default function SignedInHeader({ user }: SignedInHeaderProps) {
+  return (
+    <header className="border-b border-border/50 bg-card/80 backdrop-blur-md sticky top-0 z-50">
+      <div className="container mx-auto px-4 py-3">
+        <div className="flex items-center justify-between">
+          <Link href="/" className="font-semibold text-sm hover:underline">
+            Makkara
+          </Link>
+          <div className="flex items-center gap-3">
+            {user.image && (
+              <img
+                src={user.image}
+                alt={user.name ?? "avatar"}
+                className="w-6 h-6 rounded-full border border-border"
+              />
+            )}
+            <button
+              onClick={() => signOut()}
+              className="text-sm font-medium hover:underline"
+            >
+              Sign out
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- show a small header when a session is present
- wire up sign-out button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb726740832f906ab85878e0b951