### PR TITLE
Add sitemap and robots routes

### DIFF
--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,7 @@
+import type { NextRequest } from "next/server";
+
+export function GET(request: NextRequest) {
+  const baseUrl = request.nextUrl.origin;
+  const body = `User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml`;
+  return new Response(body, { headers: { "Content-Type": "text/plain" } });
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from "next/server";
+
+const routes = [
+  "",
+  "/login",
+  "/dashboard",
+  "/pricing",
+  "/privacy",
+  "/terms",
+  "/chat",
+];
+
+export function GET(request: NextRequest) {
+  const baseUrl = request.nextUrl.origin;
+  const urls = routes
+    .map((route) => `<url><loc>${baseUrl}${route}</loc></url>`) 
+    .join("");
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+  return new Response(sitemap, {
+    headers: { "Content-Type": "application/xml" },
+  });
+}


### PR DESCRIPTION
## Summary
- add `robots.txt` and `sitemap.xml` route handlers for Next.js

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849cf3115a4832fba85c8f0072daf46