### PR TITLE
Use API routes for account pages

### DIFF
--- a/app/account/billing/page.tsx
+++ b/app/account/billing/page.tsx
@@ -1,0 +1,46 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default async function BillingPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const res = await fetch("/api/account/subscription", { cache: "no-store" });
+
+  if (!res.ok) {
+    throw new Error("Failed to load subscription");
+  }
+
+  const { subscription } = await res.json();
+
+  const isActive = subscription?.isActive ?? false;
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Billing</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Subscription Status</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>{isActive ? "Active" : "Inactive"}</p>
+          {subscription?.stripeCustomerId && (
+            <form action="/api/billing-portal" method="POST">
+              <Button>Open Billing Portal</Button>
+            </form>
+          )}
+          {!isActive && (
+            <Button asChild>
+              <a href="/pricing">Subscribe</a>
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/account/data/page.tsx
+++ b/app/account/data/page.tsx
@@ -1,0 +1,52 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default async function AccountDataPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+  const res = await fetch("/api/account/data", { cache: "no-store" });
+
+  if (!res.ok) {
+    throw new Error("Failed to load account data");
+  }
+
+  const { user, favoriteCount, chatCount } = await res.json();
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Your Data</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Account Information</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            <strong>Email:</strong> {user.email}
+          </p>
+          <p>
+            <strong>Created:</strong> {new Date(user.createdAt).toLocaleString()}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Data Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>Favorite repositories: {favoriteCount}</p>
+          <p>Chat sessions: {chatCount}</p>
+        </CardContent>
+      </Card>
+
+      <form action="/api/delete-account" method="POST">
+        <Button variant="destructive">Delete My Data</Button>
+      </form>
+    </div>
+  );
+}

--- a/app/api/account/data/route.ts
+++ b/app/api/account/data/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/app/db";
+import { usersTable, favoriteReposTable, chatsTable } from "@/app/db/schema";
+import { eq, count } from "drizzle-orm";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const [user] = await db
+    .select({ email: usersTable.email, createdAt: usersTable.createdAt })
+    .from(usersTable)
+    .where(eq(usersTable.id, session.user.id));
+
+  const [[{ value: favoriteCount }]] = await db
+    .select({ value: count() })
+    .from(favoriteReposTable)
+    .where(eq(favoriteReposTable.userId, session.user.id));
+
+  const [[{ value: chatCount }]] = await db
+    .select({ value: count() })
+    .from(chatsTable)
+    .where(eq(chatsTable.userId, session.user.id));
+
+  return NextResponse.json({ user, favoriteCount, chatCount });
+}

--- a/app/api/account/subscription/route.ts
+++ b/app/api/account/subscription/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/app/db";
+import { subscriptionTable } from "@/app/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const [subscription] = await db
+    .select({
+      isActive: subscriptionTable.isActive,
+      stripeCustomerId: subscriptionTable.stripeCustomerId,
+    })
+    .from(subscriptionTable)
+    .where(eq(subscriptionTable.userId, session.user.id));
+
+  return NextResponse.json({ subscription });
+}

--- a/app/api/billing-portal/route.ts
+++ b/app/api/billing-portal/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/app/db";
+import { subscriptionTable } from "@/app/db/schema";
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import stripe from "@/app/config/stripe";
+
+export async function POST() {
+  const session = await auth();
+  const origin = headers().get("origin") || "";
+
+  if (!session?.user) {
+    return NextResponse.redirect(`${origin}/login`, { status: 303 });
+  }
+
+  const [subscription] = await db
+    .select({ customerId: subscriptionTable.stripeCustomerId })
+    .from(subscriptionTable)
+    .where(eq(subscriptionTable.userId, session.user.id));
+
+  if (!subscription?.customerId) {
+    return NextResponse.json({ error: "No active subscription" }, { status: 400 });
+  }
+
+  const portal = await stripe.billingPortal.sessions.create({
+    customer: subscription.customerId,
+    return_url: `${origin}/account/billing`,
+  });
+
+  return NextResponse.redirect(portal.url, { status: 303 });
+}

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/app/db";
+import { usersTable } from "@/app/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function POST() {
+  const session = await auth();
+  if (!session?.user) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  await db.delete(usersTable).where(eq(usersTable.id, session.user.id));
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,41 @@
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/sidebar-group";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const faqs = [
+  {
+    q: "How do I start a chat?",
+    a: "Navigate to the Chat page and enter a public GitHub repository in the input field.",
+  },
+  {
+    q: "Can I analyze private repositories?",
+    a: "Currently only public repositories are supported.",
+  },
+  {
+    q: "Where do I report issues?",
+    a: "Please open an issue on our GitHub project or contact support@example.com.",
+  },
+];
+
+export default function HelpPage() {
+  return (
+    <SidebarProvider defaultOpen={true}>
+      <div className="flex min-h-screen bg-gradient-to-br from-background via-background to-muted/20 w-full">
+        <AppSidebar />
+        <main className="flex-1 p-8 w-full space-y-6">
+          <h1 className="text-3xl font-bold">Help Center</h1>
+          {faqs.map((faq) => (
+            <Card key={faq.q} className="bg-card/70 backdrop-blur-md border-border/40">
+              <CardHeader>
+                <CardTitle className="text-base">{faq.q}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{faq.a}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </main>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,33 @@
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/sidebar-group";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function SettingsPage() {
+  return (
+    <SidebarProvider defaultOpen={true}>
+      <div className="flex min-h-screen bg-gradient-to-br from-background via-background to-muted/20 w-full">
+        <AppSidebar />
+        <main className="flex-1 p-8 w-full space-y-6">
+          <h1 className="text-3xl font-bold">Settings</h1>
+          <Card className="bg-card/70 backdrop-blur-md border-border/40">
+            <CardHeader>
+              <CardTitle className="text-base">Preferences</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <label className="flex items-center justify-between">
+                <span>Email Notifications</span>
+                <input type="checkbox" className="h-4 w-4" defaultChecked />
+              </label>
+              <label className="flex items-center justify-between">
+                <span>Enable Tips</span>
+                <input type="checkbox" className="h-4 w-4" />
+              </label>
+            </CardContent>
+          </Card>
+          <Button>Save Changes</Button>
+        </main>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/components/sidebar-group.tsx
+++ b/components/sidebar-group.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Sidebar,
   SidebarContent,
@@ -13,16 +15,19 @@ import {
 } from "@/components/ui/sidebar";
 import {
   LayoutDashboard,
-  FolderKanban,
   Settings,
-  Users,
-  BarChart3,
-  MessageSquare,
   HelpCircle,
   LogOut,
+  Shield,
+  CreditCard,
 } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
 
 export function AppSidebar() {
+  const pathname = usePathname();
+
   return (
     <Sidebar>
       <SidebarHeader>
@@ -39,21 +44,14 @@ export function AppSidebar() {
           <SidebarGroupLabel>Main</SidebarGroupLabel>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton isActive>
-                <LayoutDashboard className="size-4" />
-                <span>Dashboard</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
-                <FolderKanban className="size-4" />
-                <span>Projects</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
-                <BarChart3 className="size-4" />
-                <span>Analytics</span>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith("/dashboard")}
+              >
+                <Link href="/dashboard">
+                  <LayoutDashboard className="size-4" />
+                  <span>Dashboard</span>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -62,48 +60,68 @@ export function AppSidebar() {
         <SidebarSeparator />
 
         <SidebarGroup>
-          <SidebarGroupLabel>Communication</SidebarGroupLabel>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
-                <MessageSquare className="size-4" />
-                <span>Messages</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
-                <Users className="size-4" />
-                <span>Team</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroup>
-
-        <SidebarSeparator />
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Support</SidebarGroupLabel>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
+        <SidebarGroupLabel>Support</SidebarGroupLabel>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={pathname.startsWith("/help")}
+            >
+              <Link href="/help">
                 <HelpCircle className="size-4" />
                 <span>Help Center</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={pathname.startsWith("/settings")}
+            >
+              <Link href="/settings">
                 <Settings className="size-4" />
                 <span>Settings</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroup>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+
+      <SidebarSeparator />
+
+      <SidebarGroup>
+        <SidebarGroupLabel>Account</SidebarGroupLabel>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={pathname.startsWith("/account/data")}
+            >
+              <Link href="/account/data">
+                <Shield className="size-4" />
+                <span>Data</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={pathname.startsWith("/account/billing")}
+            >
+              <Link href="/account/billing">
+                <CreditCard className="size-4" />
+                <span>Billing</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
       </SidebarContent>
 
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton>
+            <SidebarMenuButton onClick={() => signOut()}>
               <LogOut className="size-4" />
               <span>Sign Out</span>
             </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- move DB queries into account API routes
- fetch account data and subscription from new endpoints
- add delete-account API route for GDPR compliance
- simplify fetch calls in account pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cacb632c832fb2b3a10537496675